### PR TITLE
docs: typo on for `.env` file

### DIFF
--- a/docs/nextjs-setup.adoc
+++ b/docs/nextjs-setup.adoc
@@ -29,7 +29,7 @@ The following file structure should now exist within your new project folder:
 .Next project files:
 [source,files]
 ----
-.evn // <1>
+.env // <1>
 src/
     components/ // <2>
     pages/


### PR DESCRIPTION
The folder overview contained a typo for environment-filename.